### PR TITLE
Importing C modules with umbrella directories prevents debugging

### DIFF
--- a/module.modulemap
+++ b/module.modulemap
@@ -1,4 +1,11 @@
 module Clang_C {
-  umbrella "."
-  module * { export * }
+  module documentation {
+    header "Documentation.h"
+    export *
+  }
+
+  module database {
+    header "CXCompilationDatabase.h"
+    export *
+  }
 }


### PR DESCRIPTION
[SR-3200](https://bugs.swift.org/browse/SR-3200) documents that importing C modules with umbrella directories cause lldb (e.g., the debugger) to have problems inspecting variables. This patch works around the issue reported in [SR-3200](https://bugs.swift.org/browse/SR-3200) by directly including the required header.

Based on the comment from @aciidb0mb3r I've switched the module map from an umbrella to directly include `Documentation.h` and `CXCompilationDatabase.h`. 

As far as I can tell, this does the same thing as the previous "umbrella" syntax but does not suffer the same lldb issues.